### PR TITLE
Missed file change notification when zero (0 byte) length files are modified

### DIFF
--- a/FSWatcher/FS/File.cs
+++ b/FSWatcher/FS/File.cs
@@ -1,29 +1,20 @@
-using System;
-
 namespace FSWatcher.FS
 {
 	class File
 	{
-		private long _hash = -1;
-
 		public string Path { get; private set; }
-		public long Hash {
-			get { 
-				if (_hash == -1)
-					_hash = getContentHash();
-				return _hash;
-			} 
-		}
+		public long Hash { get; private set; }		
 		public int Directory { get; private set; }
 
 		public File(string file, int dir) {
 			Path = file;
 			Directory = dir;
+		    Hash = getContentHash();
 		}
 
 		public void SetHash(long newHash)
 		{
-			_hash = newHash;
+			Hash = newHash;
 		}
 		
 		public override bool Equals(object obj)


### PR DESCRIPTION
I've made a small patch to FSWatcher's File class to calculate the File Hash value immediately on creation to workaround issue with missed change notification when a zero (0 byte) length file is modified.

Steps to reproduce are.
1. Create a new empty file in the target directory
2. Start the FSWatcher.Console
3. Modify the file and save it and the change will not be shown until the next time the file is saved.

Let me know if you can foresee any problems with the change I made for calculating the file's hash immediately rather than on comparison within the cache.

Cheers,
Ben
